### PR TITLE
Config options for multi-instance and public (no-auth) models

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,15 @@ This solution was designed to solve a recurring problem with users leaving their
     
     ### Example Jumpstart model configuration
 
-    **Falcon 40B - Realtime Endpoint configuration using apigateway/lambda integration**
+    **Falcon 40B - Realtime *publicly accessible* Endpoint configuration using apigateway/lambda integration**
     ```
         {
-            "name" : "Falcon40B",
+            "name" : "Falcon40BPublic",
             "model_id" : "huggingface-llm-falcon-40b-instruct-bf16",
+            "inference_instance_count": 2,
             "inference_instance_type" : "ml.g5.12xlarge",
             "inference_type": "realtime",
+            "public": true,
             "schedule": {
                 "initial_provision_minutes": 90
             },
@@ -475,6 +477,11 @@ Jumpstart model configurations
     - Description: Jumpstart model ID (A list of model id can be found [here](https://sagemaker.readthedocs.io/en/stable/doc_utils/pretrainedmodels.html))
     - Type: String
     - Required: Yes
+  - `inference_instance_count`
+    - Description: Number of instances to use for inference
+    - Type: Integer
+    - Required: No
+    - Default: 1
   - `inference_instance_type`
     - Description: Size of the instance type to use
     - Type: String
@@ -484,6 +491,11 @@ Jumpstart model configurations
     - Type: String
     - Required: Yes
     - Valid Options: `realtime` | `async`
+  - `public`
+    - Description: Whether to accept un-authenticated inference requests (without an API token) for this model
+    - Type: Boolean
+    - Required: No
+    - Default: false
   - `schedule`
     - Description: Schedule configuration for the endpoint
     - Type: [Schedule Configuration](#schedule-config) object

--- a/config/example-configs.json
+++ b/config/example-configs.json
@@ -4,10 +4,12 @@
     "ddb_auth_table_name": "AuthTable",
     "jumpstart_models" :[
         {
-            "name" : "Falcon40B",
+            "name" : "Falcon40BPublic",
             "model_id" : "huggingface-llm-falcon-40b-instruct-bf16",
+            "inference_instance_count": 2,
             "inference_instance_type" : "ml.g5.12xlarge",
             "inference_type": "realtime",
+            "public": true,
             "schedule": {
                 "initial_provision_minutes": 90
             },

--- a/stack/foundation_model_stack.py
+++ b/stack/foundation_model_stack.py
@@ -139,7 +139,7 @@ class FoundationModelStack(NestedStack):
 
                                             variant_name = "AllTraffic",
                                             variant_weight = 1,
-                                            instance_count = 1,
+                                            instance_count = model.get("inference_instance_count", 1),
                                             instance_type = model_info["instance_type"],
 
                                             environment = environment,
@@ -200,7 +200,11 @@ class FoundationModelStack(NestedStack):
                                                                             request_templates={"application/json": '{ "statusCode": "200" }'})
                     # Add lambda to api
                     resource = api_stack.api.root.add_resource(resource_name)
-                    resource.add_method("POST", post_model_integration, authorizer=api_stack.api_authorizer)
+                    resource.add_method(
+                        "POST",
+                        post_model_integration,
+                        authorizer=None if model.get("public") else api_stack.api_authorizer,
+                    )
                 elif model["integration"]["type"] == "api":
                     # Add permission to invoke endpoint
                     api_stack.api_gateway_role.add_to_policy(iam.PolicyStatement(
@@ -249,7 +253,7 @@ class FoundationModelStack(NestedStack):
                                                     )
                     resource.add_method("POST", 
                                         post_model_integration, 
-                                        authorizer=api_stack.api_authorizer,
+                                        authorizer=None if model.get("public") else api_stack.api_authorizer,
                                         request_parameters={
                                                                 "method.request.header.Content-Type": True,
                                                                 "method.request.header.Accept": True,
@@ -328,7 +332,7 @@ class FoundationModelStack(NestedStack):
 
                                 variant_name = "AllTraffic",
                                 variant_weight = 1,
-                                instance_count = 1,
+                                instance_count = model.get("inference_instance_count", 1),
                                 instance_type = model_info["instance_type"],
 
                                 environment = environment,


### PR DESCRIPTION
Add optional model configuration options:
- `inference_instance_count`, to deploy a number of instances different from the default 1 per model
- `public`, to disable the API token auth for API inference requests to a model