### PR TITLE
Basic Llama 2 and model customization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,14 @@ Jumpstart model configurations
     - Type: String
     - Required: Yes
     - Valid Options: `realtime` | `async`
+  - `model_bucket_name`:
+    - Description: Optionally override the S3 bucket name to take model data from (In case you'd like to use a modified model tarball instead of SageMaker JumpStart's default)
+    - Type: String
+    - Required: No
+  - `model_bucket_key`:
+    - Description: Optionally override the S3 object key to take model data from (In case you'd like to use a modified model tarball instead of SageMaker JumpStart's default). For example `my-folder/model.tar.gz`
+    - Type: String
+    - Required: No
   - `public`
     - Description: Whether to accept un-authenticated inference requests (without an API token) for this model
     - Type: Boolean

--- a/config/example-configs.json
+++ b/config/example-configs.json
@@ -57,6 +57,24 @@
             "model_id" : "huggingface-text2text-flan-t5-xxl",
             "inference_instance_type" : "ml.g5.8xlarge",
             "inference_type": "async"
+        },
+        {
+            "name" : "LlamaLambda",
+            "model_id" : "meta-textgeneration-llama-2-70b-f",
+            "inference_instance_count": 1,
+            "inference_instance_type" : "ml.g5.48xlarge",
+            "inference_type": "realtime",
+            "public": true,
+            "schedule": {
+                "initial_provision_minutes": 90
+            },
+            "integration": {
+                "type": "lambda",
+                "properties": {
+                    "lambda_src": "functions/falcon",
+                    "api_resource_name": "llama"
+                }
+            }
         }
     ]
 }

--- a/functions/falcon/app.py
+++ b/functions/falcon/app.py
@@ -10,12 +10,15 @@ def handler(event, context):
     payload = event['body']
 
     try:
-        response = client.invoke_endpoint(
-            EndpointName=ENDPOINT_NAME, 
-            ContentType='application/json',
-            Accept='application/json',
-            Body=payload
-        )
+        params = {
+            "Accept": "application/json",
+            "Body": payload,
+            "ContentType": "application/json",
+            "EndpointName": ENDPOINT_NAME,
+        }
+        if "headers" in event and "X-Amzn-SageMaker-Custom-Attributes" in event["headers"]:
+            params["CustomAttributes"] = event["headers"]["X-Amzn-SageMaker-Custom-Attributes"]
+        response = client.invoke_endpoint(**params)
 
         result = {
             "statusCode": 200,

--- a/functions/flan/app.py
+++ b/functions/flan/app.py
@@ -14,11 +14,15 @@ def handler(event, context):
         body = json.dumps(payload)
 
     try:
-        response = runtime.invoke_endpoint(
-            EndpointName=ENDPOINT_NAME,
-            Body=body,
-            ContentType='application/json',
-            Accept='application/json'    )
+        params = {
+            "Accept": "application/json",
+            "Body": body,
+            "ContentType": "application/json",
+            "EndpointName": ENDPOINT_NAME,
+        }
+        if "headers" in event and "X-Amzn-SageMaker-Custom-Attributes" in event["headers"]:
+            params["CustomAttributes"] = event["headers"]["X-Amzn-SageMaker-Custom-Attributes"]
+        response = runtime.invoke_endpoint(**params)
 
         response = response["Body"].read().decode('utf-8')
 

--- a/stack/foundation_model_stack.py
+++ b/stack/foundation_model_stack.py
@@ -83,6 +83,11 @@ class FoundationModelStack(NestedStack):
             model_info = get_sagemaker_uris(model_id=model["model_id"],
                                         instance_type=model["inference_instance_type"],
                                         region_name=configs["region_name"])
+            # ...with ability to override from config
+            if "model_bucket_name" in model:
+                model_info["model_bucket_name"] = model["model_bucket_name"]
+            if "model_bucket_key" in model:
+                model_info["model_bucket_key"] = model["model_bucket_key"]
 
             # Get model default environment parameters
             model_env = sagemaker_env(model_id=model["model_id"],
@@ -126,7 +131,7 @@ class FoundationModelStack(NestedStack):
                                 }
 
                 environment = merge_env(environment, model_env)
-                
+
                 endpoint = SageMakerEndpointConstruct(self, f'FoundationModelEndpoint-{model["name"]}',
                                             project_prefix = configs["project_prefix"],
                                             


### PR DESCRIPTION
1. Pass through CustomAttributes header in Falcon and Flan Lambda functions, and add an example config for using Llama 2 (which requires a CustomAttribute for EULA approval to be sent with every request) with the Falcon function
    - I'm not sure if direct API integration is also possible with Llama? Didn't have time to test
2. Support overriding model tarball location from config
    - We used this to run a Falcon endpoint with modified inference handler

Appreciate more formal/documented Llama 2 support might be preferable for (1), and (2) might be a bit niche... But was low on time so just offering what we have :-)